### PR TITLE
feat: add GitHub meta

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Code of Conduct
+
+## Our Commitment
+
+AbacatePay is committed to providing an **open, welcoming, safe, and respectful environment** for everyone who participates in our open-source ecosystem.
+
+We value collaboration, professionalism, and mutual respect, regardless of:
+- experience level
+- gender or gender identity
+- sexual orientation
+- disability
+- physical appearance or body size
+- race or ethnicity
+- age
+- religion
+- nationality
+
+This Code of Conduct applies to **all AbacatePay open-source repositories**, including:
+- all repositories under the AbacatePay GitHub organization
+- all published packages and SDKs
+- all project-related interactions (Issues, Pull Requests, discussions, code reviews, and comments)
+
+---
+
+## Expected Behavior
+
+All contributors are expected to:
+
+- Treat others with respect, empathy, and professionalism.
+- Communicate clearly, objectively, and constructively.
+- Accept constructive feedback in good faith.
+- Focus discussions on technical matters and project goals.
+- Help foster a collaborative and harassment-free environment.
+
+---
+
+## Unacceptable Behavior
+
+The following behaviors are not tolerated:
+
+- Harassment, intimidation, threats, or hostile conduct.
+- Discriminatory, offensive, or demeaning language or imagery.
+- Personal attacks unrelated to technical discussions.
+- Sexualized language or inappropriate content.
+- Unauthorized sharing of private, confidential, or sensitive information.
+- Any behavior that is inappropriate in a professional open-source context.
+
+---
+
+## Enforcement
+
+Project maintainers are responsible for enforcing this Code of Conduct.
+
+Violations may result in actions including, but not limited to:
+- a warning
+- temporary restriction from participation
+- permanent removal from AbacatePay projects
+
+Enforcement decisions are made at the maintainers’ discretion, based on severity and context.  
+Maintainers are **not obligated to publicly disclose or justify enforcement actions**.
+
+---
+
+## Reporting Violations
+
+If you experience or witness behavior that violates this Code of Conduct:
+
+- Email: **security@abacatepay.com**
+- Include relevant context when possible (links, screenshots, descriptions)
+
+All reports are reviewed seriously and handled confidentially.
+
+---
+
+## References
+
+This Code of Conduct is informed by established open-source best practices, including the **Contributor Covenant**.
+
+For security-related concerns, please refer to `SECURITY.md`.
+
+---
+
+Mutual respect is the foundation for building reliable, secure, and high-quality software — together. 🥑

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,126 @@
+# Contributing to AbacatePay
+
+Thank you for your interest in contributing to the **AbacatePay open-source ecosystem** 🥑  
+We maintain multiple official repositories, SDKs, adapters, and tools to help developers integrate payments reliably and securely.
+
+These guidelines apply to **all repositories under the AbacatePay organization**, unless stated otherwise in a specific repo.
+
+---
+
+## Code of Conduct
+
+All contributors are expected to follow the **AbacatePay Code of Conduct**.
+
+Unacceptable behavior should be reported to  
+📧 **security@abacatepay.com**
+
+---
+
+## Issues First
+
+**Opening a GitHub Issue before submitting a Pull Request is required**, except for trivial changes such as:
+- typos
+- small documentation fixes
+- non-functional formatting changes
+
+Why this matters:
+- Aligns contributions with maintainers and roadmap
+- Avoids duplicated or rejected work
+- Saves everyone time
+
+Please wait for feedback or approval before starting significant work.
+
+---
+
+## Ways to Contribute
+
+You can contribute by:
+- Reporting bugs
+- Suggesting features or improvements
+- Improving documentation
+- Adding examples or integrations
+- Submitting code via Pull Requests
+
+All contributions are welcome, as long as they follow these guidelines.
+
+---
+
+## Contribution Flow
+
+1. **Fork** the repository you want to contribute to
+2. **Create a branch** from the default branch (`main`)
+3. **Follow the setup instructions** of that repository
+4. **Write clean, focused changes**
+   - Add tests when applicable
+   - Update documentation if behavior changes
+5. **Commit using Conventional Commits**
+6. **Open a Pull Request**
+   - Link the related Issue
+   - Clearly describe what and why
+
+---
+
+## Commits
+
+We use **Conventional Commits** across all repositories.
+
+Examples:
+- `feat: add new webhook event`
+- `fix: handle retry on timeout`
+- `docs: update installation guide`
+- `chore: update GitHub templates`
+
+Guidelines:
+- Keep commits focused and meaningful
+- Do not mix unrelated changes
+- Never commit secrets or credentials
+
+---
+
+## Versioning & Releases
+
+Some repositories use **Changesets** for versioning.
+
+If required by the project:
+
+```bash
+bunx changeset
+```
+
+Follow semantic versioning:
+
+- **patch** – bug fixes
+- **minor** – backward-compatible features
+- **major** – breaking changes
+
+Always follow the repository’s existing release process.
+
+## Review Process
+
+- All Pull Requests are reviewed by maintainers
+- CI checks must pass before approval
+- Feedback is part of the process — be ready to iterate
+
+Maintainers may request changes to ensure consistency, security, and long-term maintainability.
+
+## What to Avoid
+
+- Submitting PRs without an approved Issue (When required)
+- Mixing multiple unrelated changes in one PR
+- Vague commit messages or PR descriptions
+- Ignoring CI failures or review comments
+- Introducing breaking changes without discussion
+
+## Security
+
+**Do not report security issues publicly.**
+
+If you discover a vulnerability:
+
+- Follow the instructions in SECURITY.md, or
+- Contact: [security@abacatepay.com](mailto:security@abacatepay.com)
+
+Thanks for contributing to **AbacatePay**.
+Your work helps build reliable, secure, and developer-friendly payment infrastructure.
+
+Open source, for real. 🥑

--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,2 @@
+github: AbacatePay
+custom: https://abacatepay.com

--- a/ISSUE_TEMPLATE/bug_report.yml
+++ b/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,33 @@
+name: Bug report
+description: Report a reproducible bug
+labels: [bug]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Package / Version
+      placeholder: "@abacatepay/sdk@x.y.z"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or errors
+      render: shell

--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security issue
+    url: mailto:security@abacatepay.com
+    about: Report security vulnerabilities

--- a/ISSUE_TEMPLATE/feature_request.yml
+++ b/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,17 @@
+name: Feature request
+description: Suggest an idea or improvement
+labels: [enhancement]
+
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!-- We appreciate this, thanks! -->
+## Summary
+One-paragraph explanation of the change.
+
+## Related Issue
+
+Closes (N/A)
+
+## Why
+What problem does this solve?
+
+## What changed
+- 
+- 
+- 
+
+## Breaking changes
+- [ ] Yes
+- [ ] No
+
+## Checklist
+- [ ] Docs updated
+- [ ] CI passing
+- [ ] I followed the CONTRIBUTING guidelines
+- [ ] I added or updated tests (if applicable)
+
+## Additional context
+
+Add any other context or screenshots here.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,80 @@
+# Security Policy
+
+At **AbacatePay**, we take security seriously and are committed to protecting
+our users, partners, and the open-source community that relies on our libraries,
+SDKs, and tools.
+
+This document describes how to responsibly report security vulnerabilities
+found in any AbacatePay open-source project.
+
+---
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, **do not open a public GitHub Issue**.
+
+Instead, report it through one of the following channels:
+
+- **Email:** security@abacatepay.com  
+- **GitHub Security Advisories** (preferred, when available)
+
+When reporting a vulnerability, please include as much detail as possible:
+
+- A clear and concise description of the issue
+- Steps to reproduce (if applicable)
+- Potential impact and affected components
+- Any known mitigations or suggested fixes
+
+---
+
+## Response Process
+
+Once a vulnerability is reported:
+
+- We will acknowledge receipt within **48 business hours**
+- The report will be reviewed and triaged by the maintainers
+- A fix will be developed based on severity and impact
+- We will coordinate a responsible disclosure after a fix is available
+
+Timelines may vary depending on complexity and severity, but we aim to act as
+quickly and transparently as possible.
+
+---
+
+## Responsible Disclosure
+
+We kindly ask that you **do not publicly disclose** any vulnerability
+until we have had the opportunity to investigate and address it.
+
+We strongly support and appreciate responsible disclosure practices and
+collaboration with security researchers.
+
+---
+
+## Credentials and Secrets
+
+Accidental exposure of API keys, tokens, secrets, or other sensitive credentials
+is considered **critical severity**.
+
+If you believe credentials have been leaked:
+
+- Report the issue immediately using the channels above
+- Avoid sharing the exposed data publicly
+- Revoke or rotate the affected credentials as soon as possible
+
+---
+
+## Scope
+
+This security policy applies to **all repositories and packages**
+maintained under the AbacatePay GitHub organization, including all
+open-source libraries, SDKs, and tools.
+
+---
+
+## Acknowledgements
+
+We appreciate the efforts of security researchers and contributors
+who help keep the AbacatePay ecosystem secure.
+
+Thank you for helping us improve the safety and reliability of our software. 🥑

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,85 @@
+# Support
+
+Thanks for using **AbacatePay** open-source projects 🥑  
+This document explains **where to get help** and **how to ask for support** effectively.
+
+---
+
+## Getting Help
+
+We offer support through the following channels:
+
+### Documentation (First Stop)
+
+Before asking for help, please check:
+
+- Official documentation
+- README files of the relevant repository or package
+- Examples and usage guides
+
+Most common questions are already answered there.
+
+---
+
+### Bug Reports & Feature Requests
+
+If you believe you’ve found a bug or want to suggest an improvement:
+
+- Open a **GitHub Issue** in the relevant repository
+- Follow the provided issue templates
+- Include as much context as possible (environment, versions, logs, steps to reproduce)
+
+Please **do not** use Issues for general questions or support requests.
+
+---
+
+### Questions & Usage Help
+
+For general questions, usage help, or implementation guidance:
+
+- Use **GitHub Discussions** (when enabled on the repository)
+- Clearly describe what you’re trying to achieve and what you’ve already tried
+
+This helps maintainers and other community members assist you more effectively.
+
+---
+
+### Security Issues
+
+If your question involves a **security concern**:
+
+- **Do not open a public issue**
+- Follow the instructions in [`SECURITY.md`](SECURITY.md)
+- Contact: **security@abacatepay.com**
+
+---
+
+## What We Cannot Support
+
+Please note that maintainers cannot provide:
+
+- Personalized debugging or consulting
+- Support for modified or forked versions of the code
+- Help with unrelated third-party libraries
+- Urgent or SLA-based support through GitHub
+
+---
+
+## Commercial & Enterprise Support
+
+For enterprise support, custom integrations, or commercial inquiries:
+
+- Contact the AbacatePay team through official channels
+
+---
+
+## Be Respectful
+
+AbacatePay maintainers contribute to open source with limited time.
+Please be respectful, patient, and constructive in all interactions.
+
+Following this guide helps keep the community productive and sustainable.
+
+---
+
+Thank you for being part of the AbacatePay ecosystem.


### PR DESCRIPTION
Este PR adiciona arquivos especiais ao repositório `.github` da AbacatePay, centralizando configurações e padrões que passam a ser aplicados automaticamente a todos os repositórios públicos da organização.

### O que foi adicionado

- `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` e `SUPPORT.md`  
  - Arquivos base de governança e contribuição, válidos para todos os repositórios públicos.

- `FUNDING.yml`  
  - Habilita o botão de Sponsors em todos os repositórios da organização.

- `PULL_REQUEST_TEMPLATE.md`  
  - Define um template padrão para Pull Requests, melhorando consistência e revisão.

- `ISSUE_TEMPLATE/` (`config.yml`, `feature_request.yml`, `bug_report.yml`)  
  - Padroniza a criação de issues (bugs e sugestões de feature).

### Observações

- Não há alterações de código ou comportamento em runtime.
- As mudanças afetam apenas governança, templates e metadados do GitHub.
