### PR TITLE
fix: atualiza link do Discord para convite permanente

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -30,7 +30,7 @@ export const POST = Webhooks({
 
 ## Junte-se à revolução, use a AbacatePay
 
-Junte-se conosco e venha fazer parte da comunidade da *AbacatePay no [Discord](https://discord.gg/HVNWYE5V)* e nos ajuda a revolucionar o ecossistema de pagamentos no Brasil!
+Junte-se conosco e venha fazer parte da comunidade da *AbacatePay no [Discord](https://discord.gg/SKArpBqju4)* e nos ajuda a revolucionar o ecossistema de pagamentos no Brasil!
 
 ---
 


### PR DESCRIPTION
<!-- We appreciate this, thanks! -->
## Summary
Substituído o link de convite do Discord que estava expirado por um convite permanente (sem data de expiração).

## Related Issue

Closes #6

## Why
What problem does this solve?

O link anterior redirecionava para uma tela de convite inválido, impedindo contribuidores de entrar no servidor da AbacatePay.

## What changed
- Atualizado o link do Discord no profile/README.md para um convite permanente. 

## Breaking changes
- [ ] Yes
- [X] No

## Checklist
- [X] Docs updated
- [ ] CI passing
- [X] I followed the CONTRIBUTING guidelines
- [ ] I added or updated tests (if applicable)

## Additional context

Link gerado com expiração definida como "Nunca" nas configurações do Discord.

Add any other context or screenshots here.
